### PR TITLE
use /usr/bin/python in the shebang

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -354,7 +354,7 @@ class AnsibleModuleBase:
 
     def renderer(self, target_dir):
         DEFAULT_MODULE = """
-#!/usr/bin/python3
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)


### PR DESCRIPTION
Technically speaking, we should use `/usr/bin/python3`. But `ansible-test sanity` raise an error. So let's switch back to that for now.