### PR TITLE
ignore end-points with Tech Preview status

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -797,6 +797,12 @@ class Path:
     def summary(self, verb):
         return self.value[verb]["summary"]
 
+    def is_tech_preview(self):
+        for verb in self.value.keys():
+            if "Technology Preview" in self.summary(verb):
+                return True
+        return False
+
 
 class SwaggerFile:
     def __init__(self, file_path):
@@ -812,6 +818,9 @@ class SwaggerFile:
         result = {}
 
         for path in [Path(p, v) for p, v in paths.items()]:
+            if path.is_tech_preview():
+                print(f"Skipping {path.path} (Technology Preview)")
+                continue
             if path not in paths:
                 result[path.path] = path
             for verb, desc in path.value.items():

--- a/test_refresh_modules.py
+++ b/test_refresh_modules.py
@@ -123,6 +123,7 @@ my_raw_paths_data = {
                     "type": "string",
                 }
             ],
+            "summary": "",
             "responses": {
                 "200": {
                     "description": "Information about the VM.",
@@ -150,6 +151,7 @@ my_raw_paths_data = {
                     "type": "array",
                 }
             ],
+            "summary": "",
             "responses": {
                 "200": {
                     "description": "A list",
@@ -196,6 +198,7 @@ my_raw_paths_data_with_param_in_path = {
                     "type": "string",
                 },
             ],
+            "summary": "",
             "responses": {
                 "200": {
                     "description": "Identifier of the virtual machine that was checked out of the library item.",
@@ -241,6 +244,7 @@ my_raw_paths_data_with_param_in_path = {
                     "type": "string",
                 },
             ],
+            "summary": "",
             "responses": {
                 "200": {
                     "description": "The new version of the library item.",


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware_rest_code_generator/pull/7

Do not build the modules when they depend on API with the Technology
Previous status:

- vcenter_vm_compute_policies_info
- vcenter_vm_console_tickets