### PR TITLE
don't generate vcenter_vm_guest_power* modules

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -268,7 +268,11 @@ class AnsibleModuleBase:
             "vcenter_network_info",
             "vcenter_vm($|_.+)",
         ]
-        if self.name in ["vcenter_vm_guest_customization"]:
+        if self.name in [
+            "vcenter_vm_guest_customization",
+            "vcenter_vm_guest_power",
+            "vcenter_vm_guest_power_info",
+        ]:
             return False
 
         regexes = [re.compile(i) for i in trusted_module_allowlist]


### PR DESCRIPTION
Skip vcenter_vm_guest_power and vcenter_vm_guest_power_info because
we've already vcenter_vm_power and vcenter_vm_power_info.

Depends-On: https://github.com/ansible-collections/vmware_rest/pull/71