### PR TITLE
avoid action module like foo_disconnect

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -160,15 +160,18 @@ def format_documentation(documentation):
 
 
 def path_to_name(path):
-    def is_element(i):
-        if i and "{" not in i:
-            return True
+    _path = path.lstrip("/").split("?")[0]
+    elements = []
+    keys = []
+    for i in _path.split("/"):
+        if "{" in i:
+            keys.append(i)
+        elif len(keys) > 1:
+            # action for a submodule, we gather these end-points in the main module
+            continue
         else:
-            return False
+            elements.append(i)
 
-    _path = path.split("?")[0]
-
-    elements = [i for i in _path.split("/") if is_element(i)]
     # workaround for vcenter_vm_power
     if elements[-1] in ("stop", "start", "suspend", "reset"):
         elements = elements[:-1]

--- a/test_refresh_modules.py
+++ b/test_refresh_modules.py
@@ -369,7 +369,7 @@ def test_path_to_name():
     )
     assert (
         rm.path_to_name("/rest/vcenter/vm/{vm}/hardware/ethernet/{nic}/disconnect")
-        == "vcenter_vm_hardware_ethernet_disconnect"
+        == "vcenter_vm_hardware_ethernet"
     )
 
 


### PR DESCRIPTION
Now, what was in `vcenter_vm_hardware_ethernet_disconnect` is now part of
`vcenter_vm_hardware_ethernet`. The user can use `state: disconnect` to
trigger the end-point.
This is a more Ansibl-ish approach and this will reduce the number of modules.