### PR TITLE
doc: improve the idempotency of the result

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -366,9 +366,15 @@ class AnsibleModuleBase:
         return payload
 
     def parameters(self):
+        def sort_operationsid(input):
+            output = sorted(input)
+            if "create" in output:
+                output = ["create"] + output
+            return output
 
         results = {}
-        for operationId in self.default_operationIds:
+
+        for operationId in sort_operationsid(self.default_operationIds):
             if operationId not in self.resource.operations:
                 continue
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/643

- loop on the operations in the same order all the time.
- always starts with "create" because the result looks better.