### PR TITLE
ensure state field is required or default

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -467,6 +467,8 @@ class AnsibleModuleBase:
             results["state"]["default"] = "present"
         elif "set" in states:
             results["state"]["default"] = "set"
+        elif states:
+            results["state"]["required"] = True
 
         return sorted(results.values(), key=lambda item: item["name"])
 


### PR DESCRIPTION
Ensure the `state` field is either:
- required == True
- or comes with a default value.