### PR TITLE
vcenter_rest_log_file: add ability to record the HTTP interaction

### DIFF
--- a/module_utils/vmware_rest.py
+++ b/module_utils/vmware_rest.py
@@ -7,12 +7,14 @@ async def open_session(
     vcenter_username=None,
     vcenter_password=None,
     validate_certs=True,
+    log_file=None,
 ):
-
     m = hashlib.sha256()
     m.update(vcenter_hostname.encode())
     m.update(vcenter_username.encode())
     m.update(vcenter_password.encode())
+    if log_file:
+        m.update(log_file.encode())
     m.update(b"yes" if validate_certs else b"no")
     digest = m.hexdigest()
     # TODO: Handle session timeout
@@ -27,10 +29,28 @@ async def open_session(
 
         raise EmbeddedModuleFailure()
 
+    if log_file:
+        trace_config = aiohttp.TraceConfig()
+
+        async def on_request_end(session, trace_config_ctx, params):
+            with open(log_file, "a+") as fd:
+                answer = await params.response.text()
+                fd.write(
+                    f"{params.method}: {params.url}\n"
+                    f"headers: {params.headers}\n"
+                    f"  status: {params.response.status}\n"
+                    f"  answer: {answer}\n\n"
+                )
+
+        trace_config.on_request_end.append(on_request_end)
+        trace_configs = [trace_config]
+    else:
+        trace_configs = []
+
     auth = aiohttp.BasicAuth(vcenter_username, vcenter_password)
     connector = aiohttp.TCPConnector(limit=20, ssl=validate_certs)
     async with aiohttp.ClientSession(
-        connector=connector, connector_owner=False
+        connector=connector, connector_owner=False, trace_configs=trace_configs
     ) as session:
         async with session.post(
             "https://{hostname}/rest/com/vmware/cis/session".format(
@@ -57,6 +77,7 @@ async def open_session(
                     "content-type": "application/json",
                 },
                 connector_owner=False,
+                trace_configs=trace_configs,
             )
             open_session._pool[digest] = session
             return session

--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -162,6 +162,14 @@ def gen_documentation(name, description, parameters):
                 "type": "bool",
                 "default": True,
             },
+            "vcenter_rest_log_file": {
+                "description": [
+                    "You can use this optional parameter to set the location of a log file. ",
+                    "This file will be used to record the HTTP REST interaction. ",
+                    "The file will be stored on the host that run the module. ",
+                ],
+                "type": "str",
+            },
         },
         "requirements": ["python >= 3.6", "aiohttp"],
         "short_description": description,
@@ -753,6 +761,11 @@ def prepare_argument_spec():
             required=False,
             default=True,
             fallback=(env_fallback, ['VMWARE_VALIDATE_CERTS']),
+        ),
+        "vcenter_rest_log_file": dict(
+            type='str',
+            required=False,
+            fallback=(env_fallback, ['VMWARE_REST_LOG_FILE']),
         )
     }}
 
@@ -763,7 +776,7 @@ def prepare_argument_spec():
 async def main( ):
     module_args = prepare_argument_spec()
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
-    session = await open_session(vcenter_hostname=module.params['vcenter_hostname'], vcenter_username=module.params['vcenter_username'], vcenter_password=module.params['vcenter_password'])
+    session = await open_session(vcenter_hostname=module.params['vcenter_hostname'], vcenter_username=module.params['vcenter_username'], vcenter_password=module.params['vcenter_password'], log_file=module.params['vcenter_rest_log_file'])
     result = await entry_point(module, session)
     module.exit_json(**result)
 


### PR DESCRIPTION
vcenter_rest_log_file: this optional parameter can be used to point on the
log file where all the HTTP interaction will be record.