### PR TITLE
handle case where we cannot get an item by id

### DIFF
--- a/module_utils/vmware_rest.py
+++ b/module_utils/vmware_rest.py
@@ -113,6 +113,8 @@ def gen_args(params, in_query_parameter):
 
 
 async def update_changed_flag(data, status, operation):
+    if not data:
+        data = {}
     if operation == "create" and status in [200, 201]:
         data["failed"] = False
         data["changed"] = True
@@ -186,9 +188,10 @@ async def build_full_device_list(session, url, device_list):
 
 async def get_device_info(session, url, _id):
     async with session.get(url + "/" + _id) as resp:
-        _json = await resp.json()
-        _json["id"] = str(_id)
-        return _json
+        if resp.status == 200:
+            _json = await resp.json()
+            _json["id"] = str(_id)
+            return _json
 
 
 async def exists(params, session, url, unicity_keys=None):


### PR DESCRIPTION
For instance host/{host} or folder/{folder} end-points are
not defined and will return 404 error.