### PR TITLE
SSL: use certifi if available

### DIFF
--- a/changelogs/fragments/certifi.yaml
+++ b/changelogs/fragments/certifi.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ssl can now use the ``certifi`` Root Certificates. This is useful on MacOS. On Linux, ``certifi`` should redirect to the system Certificates.


### PR DESCRIPTION
Use the certifi package, if it's available. This to address the
case where `ssl` cannot access the system SSL certificates and raises
`certificate verify failed: unable to get local issuer certificate`.

This change also complexify the SSL code, an alternative is to just
ask the users to fix their set-up or disable SSL.