### PR TITLE
Revert "use raw string for EXAMPLES and RETURN"

### DIFF
--- a/refresh_modules.py
+++ b/refresh_modules.py
@@ -701,10 +701,10 @@ class AnsibleModuleBase:
 
 DOCUMENTATION = {documentation}
 
-EXAMPLES = r\"\"\"
+EXAMPLES = \"\"\"
 \"\"\"
 
-RETURN = r\"\"\"
+RETURN = \"\"\"
 \"\"\"
 
 # This structure describes the format of the data expected by the end-points


### PR DESCRIPTION
These commits break on Python3.6. This kind of situation should never
happens. I will adjust the CI to catch this kind of regression sooner
in the future.

This reverts commit:
- a0dfd64138e9b6a7d5978d54d2c39402f43f80e4
- 7ec27ed6e49238822674b34d812c442b3745874a