### PR TITLE
address the missing-python-interpreter warning

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -686,7 +686,7 @@ class AnsibleModuleBase:
 
     def renderer(self, target_dir):
         DEFAULT_MODULE = """
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)


### PR DESCRIPTION
Adjust the shebang to avoid the validate-modules error.