### PR TITLE
definitions.get: do not call flatten_ref()

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -1113,7 +1113,7 @@ class Definitions:
         if definition is None:
             raise Exception("Cannot find ref for {ref}")
 
-        return flatten_ref(definition, self.definitions)
+        return definition
 
 
 class Path:


### PR DESCRIPTION
Do not call `flatten_ref()` to avoid a dependency at this level.
We already call `flatten_ref()` when necessary.