### PR TITLE
appliance: do not generate all the modules

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -434,7 +434,6 @@ class AnsibleModuleBase:
             "^content_locallibrary_info$",
             "^content_subscribedlibrary$",
             "^content_subscribedlibrary_info$",
-            "^appliance.*$",
             "^vcenter_vm_storage_policy_compliance_info$",
         ]
         regexes = [re.compile(i) for i in trusted_module_allowlist]


### PR DESCRIPTION
We skip some of the appliance modules.