### PR TITLE
ignore pep8 for appliance_infraprofile_configs

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -988,6 +988,7 @@ def main():
     ignore_content += (
         "plugins/module_utils/vmware_rest.py future-import-boilerplate!skip\n"
         "plugins/modules/vcenter_vm_guest_customization.py pep8!skip\n"  # E501: line too long (189 > 160 characters)
+        "plugins/modules/appliance_infraprofile_configs.py pep8!skip\n"  # E501: line too long (302 > 160 characters)
     )
     files = ["plugins/modules/{}.py".format(module) for module in module_list]
     for f in files:


### PR DESCRIPTION
This because of some long lines in the RETURNS section.