### PR TITLE
Add Code of Conduct reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ Run `ansible-test` to validate the result:
     source ~/tmp/venv-tmp-py36-vmware/bin/activate
     pip install -r requirements.txt -r test-requirements.txt ansible
     ansible-test sanity --requirements --local --python 3.6 -vvv
+
+## Code of Conduct
+
+This project is governed by the [Ansible Community code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)


### PR DESCRIPTION
##### SUMMARY
Add Code of Conduct reference to README

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
README

##### ADDITIONAL INFORMATION
Ansible managed collections have always been under the CoC, but let's be explicit