### PR TITLE
Attempt to fix documentation generation for vcenter_password

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -161,7 +161,7 @@ def gen_documentation(name, description, parameters):
             },
             "vcenter_password": {
                 "description": [
-                    "The vSphere vCenter username",
+                    "The vSphere vCenter password",
                     "If the value is not specified in the task, the value of environment variable C(VMWARE_PASSWORD) will be used instead.",
                 ],
                 "type": "str",

--- a/vmware_rest_code_generator/cmd/test_refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/test_refresh_modules.py
@@ -72,7 +72,7 @@ documentation_data_input = {
         },
         "vcenter_password": {
             "description": [
-                "The vSphere vCenter " "username",
+                "The vSphere vCenter " "password",
                 "If the value is not "
                 "specified in the task, the "
                 "value of environment "
@@ -406,7 +406,7 @@ options:
     type: str
   vcenter_password:
     description:
-    - The vSphere vCenter username
+    - The vSphere vCenter password
     - If the value is not specified in the task, the value of environment variable
       C(VMWARE_PASSWORD) will be used instead.
     required: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The documentation reports a wrong description for the `vcenter_password` parameter:
```yaml
  vcenter_password: 
      description:
           - The vSphere vCenter username 
```
It should be
```yaml
  vcenter_password: 
      description:
           - The vSphere vCenter password 
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

