### PR TITLE
remove the _debug_info field from the result

### DIFF
--- a/vmware_rest_code_generator/module_utils/vmware_rest.py
+++ b/vmware_rest_code_generator/module_utils/vmware_rest.py
@@ -209,7 +209,6 @@ async def update_changed_flag(data, status, operation):
     elif data.get("type", "").startswith("com.vmware.vapi.std.errors"):
         data["failed"] = True
 
-    data["_debug_info"] = {"status": status, "operation": operation}
     return data
 
 


### PR DESCRIPTION
We don't need this anymore and it's confusing for the users.