### PR TITLE
content.json: remove a unexpected parameter

### DIFF
--- a/vmware_rest_code_generator/api_specifications/7.0.2/content.json
+++ b/vmware_rest_code_generator/api_specifications/7.0.2/content.json
@@ -1800,7 +1800,7 @@
                 ]
             }
         },
-        "/api/content/library/item?library_id": {
+        "/api/content/library/item": {
             "get": {
                 "tags": [
                     "library/item"


### PR DESCRIPTION
The `/api/content/library/item` end-point expect a named argument. e.g:
`/api/content/library/item?library_id=foo`

If we keep the original string, we end-up with
`/api/content/library/item?library&library_id=foo` in the final module.