### PR TITLE
Overwrite documentation of vcenter vm  power modules

### DIFF
--- a/vmware_rest_code_generator/cmd/test_refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/test_refresh_modules.py
@@ -35,7 +35,7 @@ documentation_data_input = {
     "author": ["Goneri Le Bouder (@goneri) <goneri@lebouder.net>"],
     "description": "bar",
     "module": "foo",
-    "notes": ["Tested on vSphere 7.0"],
+    "notes": ["Tested on vSphere 7.0.2"],
     "options": {
         "aaa": {
             "description": [
@@ -395,7 +395,7 @@ options:
     - b
     - c
     description:
-    - '3rd parameter is : enum,'
+    - 3rd parameter is ':' enum,
     - ''
     - and this string is long and comes with a ' on purpose. This way, we can use
       it to ensure format_documentation() can break it up.
@@ -420,6 +420,8 @@ version_added: 1.0.0
 requirements:
 - python >= 3.6
 - aiohttp
+notes:
+- Tested on vSphere 7.0.2
 '''"""
 
     assert rm.format_documentation(documentation_data_input) == expectation

--- a/vmware_rest_code_generator/config/modules.yaml
+++ b/vmware_rest_code_generator/config/modules.yaml
@@ -101,6 +101,12 @@
 - vcenter_vm_guest_operations_info:
 - vcenter_vm_guest_power_info:
 - vcenter_vm_guest_power:
+    documentation:
+      short_description: Issues a request to the guest operating system asking it to perform a soft shutdown, standby (suspend) or soft reboot
+      seealso:
+        - module: vmware.vmware_rest.vcenter_vm_power
+          description: A module to boot, hard shutdown and hard reset guest
+      description: Issues a request to the guest operating system asking it to perform a soft shutdown, standby (suspend) or soft reboot. This request returns immediately and does not wait for the guest operating.
 - vcenter_vm_guest_processes_info:
 - vcenter_vm_guest_processes:
 - vcenter_vm_hardware_adapter_sata_info:
@@ -133,6 +139,12 @@
 - vcenter_vm_libraryitem_info:
 - vcenter_vm_power_info:
 - vcenter_vm_power:
+    documentation:
+      short_description:  Operate a boot, hard shutdown, hard reset or hard suspend on a guest.
+      seealso:
+        - module: vmware.vmware_rest.vcenter_vm_guest_power
+          description: Issues a request to the guest operating system asking it to perform a soft shutdown, standby (suspend) or soft reboot
+      description: Ask the vCenter to boot, force shutdown or force reset a guest. If you want to do a soft shutdown or a soft reset, you can use M(vmware.vmware_rest.vmware_vm_guest_power) instead.
 - vcenter_vm:
 - vcenter_vm_storage_policy_compliance_info:
 - vcenter_vm_storage_policy_compliance:


### PR DESCRIPTION
overwrite documentation of vcenter_vm_*power modules
    
Read the documentation from the config/modules.yaml configuration file.

See: https://github.com/ansible-collections/vmware.vmware_rest/issues/124