### PR TITLE
PUT: raise an error in case of !300< err code

### DIFF
--- a/vmware_rest_code_generator/templates/default_module.j2
+++ b/vmware_rest_code_generator/templates/default_module.j2
@@ -186,10 +186,11 @@ async def _set(params, session):
            _json = {"value": _json}
         # The PUT answer does not let us know if the resource has actually been
         # modified
-        async with session.get(_url, json=payload, **session_timeout(params)) as resp_get:
-            after = await resp_get.json()
-            if before == after:
-                return await update_changed_flag(after, resp_get.status, "get")
+        if resp.status < 300:
+                async with session.get(_url, json=payload, **session_timeout(params)) as resp_get:
+                    after = await resp_get.json()
+                    if before == after:
+                        return await update_changed_flag(after, resp_get.status, "get")
         return await update_changed_flag(_json, resp.status, "set")
 
 


### PR DESCRIPTION
vcenter_vm_guest_customization was silently returning 400 or 500+
errors. The module was ignoring the error code and returning a success
message. This is not the case anymore.

Thanks Jerry Corum for reporting this.