### PR TITLE
setup.cfg: use a wildcare to import the conf file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ package-data = vmware_rest_code_generator =
     templates/*.j2
 data-files =
     vmware_rest_code_generator/api_specifications = api_specifications/*
-    vmware_rest_code_generator/config = config/modules.yaml
+    vmware_rest_code_generator/config = config/*
     vmware_rest_code_generator/module_utils = module_utils/*
 
 [entry_points]


### PR DESCRIPTION
This to avoid the following error:

error: can't copy 'config/modules.yaml': doesn't exist or not a regular file