### PR TITLE
do not mangle the subkey data structure

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -789,16 +789,19 @@ class AnsibleModuleBase:
                 "in": v.get("in"),
             }
             if "enum" in v:
-                parameter["enum"] = v["enum"]
+                parameter["enum"] = sorted(set(v["enum"]))
 
             sub_items = None
             required_subkeys = v.get("required", [])
+
             if "properties" in v:
                 sub_items = v["properties"]
-                required_subkeys = v["properties"].get("required", [])
+                if "required" in v["properties"]:  # NOTE: do we still need these
+                    required_subkeys = v["properties"]["required"]
             elif "items" in v and "properties" in v["items"]:
                 sub_items = v["items"]["properties"]
-                required_subkeys = v["items"].get("required", [])
+                if "required" in v["items"]:  # NOTE: do we still need these
+                    required_subkeys = v["items"]["required"]
             elif "items" in v and "name" not in v["items"]:
                 parameter["elements"] = v["items"].get("type", "str")
             elif "items" in v and v["items"]["name"]:

--- a/vmware_rest_code_generator/templates/default_module.j2
+++ b/vmware_rest_code_generator/templates/default_module.j2
@@ -115,25 +115,16 @@ async def _update(params, session):
         for k, v in value.items():
             if k in payload:
                 if isinstance(payload[k], dict) and isinstance(v, dict):
+                    to_delete = True
                     for _k in list(payload[k].keys()):
-                        if payload[k][_k] == v.get(_k):
-                            del payload[k][_k]
-                if payload[k] == v  or payload[k] == {}:
+                        if payload[k][_k] != v.get(_k):
+                            to_delete = False
+                    if to_delete:
+                        del payload[k]
+                elif payload[k] == v:
                     del payload[k]
-            elif "spec" in payload:  # 7.0.2 <
-                if k in payload["spec"] and payload["spec"][k] == v:
-                    del payload["spec"][k]
-
-
-        {% if name == "vcenter_vm_hardware" -%}
-        # NOTE: workaround for vcenter_vm_hardware, upgrade_version needs the upgrade_policy
-        # option. So we ensure it's here.
-        try:
-            if payload["spec"]["upgrade_version"] and "upgrade_policy" not in payload["spec"]:
-                payload["spec"]["upgrade_policy"] = _json["value"]["upgrade_policy"]
-        except KeyError:
-            pass
-        {% endif -%}
+                elif payload[k] == {}:
+                    del payload[k]
 
         if payload == {} or payload == {"spec": {}}:
             # Nothing has changed
@@ -204,8 +195,8 @@ async def _{{ operation  }}(params, session):
         ):
             # vSphere 7.0.2, a network configuration changes of the appliance raise a systemd error,
             # but the change is applied. The problem can be resolved by a yum update.
-            async with session.get(_url, json=payload, **session_timeout(params)) as resp:
-                _json = {"value": await resp.json()}
+            async with session.get(_url, json=payload, **session_timeout(params)) as resp_dns_servers:
+                _json = {"value": await resp_dns_servers.json()}
         {% endif %}
 
 


### PR DESCRIPTION
We need to preserve the whole subkey content to be sure the result will
behave as expect.
This allow us to remove an existing workaround for vcenter_vm_hardware.

See: https://github.com/ansible-collections/vmware.vmware_rest/issues/267
