### PR TITLE
subdevice and {} in URL

### DIFF
--- a/vmware_rest_code_generator/module_utils/vmware_rest.py
+++ b/vmware_rest_code_generator/module_utils/vmware_rest.py
@@ -344,7 +344,7 @@ def get_subdevice_type(url):
             candidates.append(i[1:-1])
     if len(candidates) != 2:
         return
-    return candidates[-1]
+    return candidates[-1].split("}")[0]
 
 
 def get_device_type(url):


### PR DESCRIPTION
Properly return the subdevice if the URL comes with a {...} pattern.
