### PR TITLE
no error if we get NOT_FOUND on a state=absent

### DIFF
--- a/vmware_rest_code_generator/module_utils/vmware_rest.py
+++ b/vmware_rest_code_generator/module_utils/vmware_rest.py
@@ -207,6 +207,12 @@ async def update_changed_flag(data, status, operation):
     elif data.get("type") == "com.vmware.vapi.std.errors.already_exists":
         data["failed"] = False
         data["changed"] = False
+    elif (
+        data.get("value", {}).get("error_type") in ["NOT_FOUND"]
+        and operation == "delete"
+    ):
+        data["failed"] = False
+        data["changed"] = False
     elif data.get("value", {}).get("error_type") in [
         "ALREADY_EXISTS",
         "ALREADY_IN_DESIRED_STATE",


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1236

Problem identified with:

```
vcenter_datacenter:
  name: foo
  state: absent
```

If `foo` does not exist, we get a 404 error that we should handle
as a success.
