### PR TITLE
tests: depends on ansible-core, not ansible

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 flake8
 pytest
-ansible
+ansible-core


### PR DESCRIPTION
We don't need to depend on the full ansible distribution for the tests.
