### PR TITLE
commit_modules.sh: tests/output/.tmp may not exist

### DIFF
--- a/commit_modules.sh
+++ b/commit_modules.sh
@@ -35,7 +35,7 @@ find docs/docsite/rst/ -name '*.rst' -exec sed -i 's,’,",g' '{}' \;
 
 ansible-test sanity --local --python $(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")') -vvv
 rm -r docs/docsite/rst/.doctrees
-rm -r tests/output/.tmp
+rm -rf tests/output/.tmp
 tox -e linters
 git add CHANGELOG.rst README.md dev.md plugins docs tests/sanity/ignore-*.txt
 tox -e antsibull-changelog -- release --verbose --version ${version}


### PR DESCRIPTION
tests/output/.tmp presence depends on the Ansible version.
