### PR TITLE
commit_modules.sh: import CHANGELOG.rst once it's generated

### DIFF
--- a/commit_modules.sh
+++ b/commit_modules.sh
@@ -39,7 +39,7 @@ ansible-test sanity --local --python $(python3 -c 'import sys;print(f"{sys.versi
 rm -r docs/docsite/rst/.doctrees
 rm -r tests/output/.tmp
 tox -e linters
-git add CHANGELOG.rst README.md dev.md plugins docs tests/sanity/ignore-*.txt
 tox -e antsibull-changelog -- release --verbose --version ${version}
+git add CHANGELOG.rst README.md dev.md plugins docs tests/sanity/ignore-*.txt
 git add changelogs
 git commit -S -F commit_message


### PR DESCRIPTION
Don't git add CHANGELOG.rst too early.
