### PR TITLE
ignore end-points where they return a task id

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -991,6 +991,9 @@ class SwaggerFile:
     def init_resources(paths):
         resources = {}
         for path in paths:
+            if "vmw-task=true" in path.path:
+                continue
+
             name = path_to_name(path.path)
             if name == "esx_settings_clusters_software_drafts":
                 continue


### PR DESCRIPTION
We don't support yet these async tasks.
