### PR TITLE
Reconcile license information in setup.cfg with LICENSE

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,11 @@ description-file =
     README.md
 author = Ansible Cloud team
 home-page = https://www.ansible.com
+license = GPLv3+
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
-    License :: OSI Approved :: Apache Software License
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
 


### PR DESCRIPTION
##### SUMMARY
License noted in setup.cfg was different from the actual LICENSE.  Correct the setup.cfg file.

Package has never been published to pypi so should only affect contributors who may have committed while there were different licenses noted.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
setup.cfg

##### ADDITIONAL INFORMATION
As this could be considered a re-licensing, all contributors with commits during the time period that Apache was listed in setup.cfg will need to ack this PR before merging.