### PR TITLE
Move functions from refresh_modules.py to shared repo

### DIFF
--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -22,9 +22,8 @@ from gouttelette.utils import (
     get_module_from_config,
     python_type,
     UtilsBase,
+    jinja2_renderer,
 )
-
-from gouttelette.utils import jinja2_renderer
 
 
 def normalize_parameter_name(name):
@@ -433,7 +432,6 @@ class Resource:
 
 class AnsibleModuleBase(UtilsBase):
     def __init__(self, resource, definitions):
-        super(AnsibleModuleBase, self).__init__()
         self.resource = resource
         self.definitions = definitions
         self.name = resource.name
@@ -787,7 +785,7 @@ class AnsibleModuleBase(UtilsBase):
         content = jinja2_renderer(
             self.template_file,
             "vmware_rest_code_generator",
-            arguments=_indent(arguments, 4),
+            arguments=indent(arguments, 4),
             documentation=documentation,
             list_index=self.list_index(),
             list_path=self.list_path(),

--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -16,6 +16,9 @@ import baron
 import redbaron
 import yaml
 from functools import lru_cache
+from gouttelette.utils import (
+    format_documentation,
+)
 
 from gouttelette.utils import jinja2_renderer
 
@@ -315,42 +318,6 @@ def gen_documentation(name, description, parameters, added_ins, next_version):
         for k, v in module_from_config["documentation"].items():
             documentation[k] = v
     return documentation
-
-
-def format_documentation(documentation):
-    def _sanitize(input):
-        if isinstance(input, str):
-            return input.replace("':'", ":")
-        if isinstance(input, list):
-            return [l.replace("':'", ":") for l in input]
-        if isinstance(input, dict):
-            return {k: _sanitize(v) for k, v in input.items()}
-        if isinstance(input, bool):
-            return input
-        raise TypeError
-
-    keys = [
-        "module",
-        "short_description",
-        "description",
-        "options",
-        "author",
-        "version_added",
-        "requirements",
-        "seealso",
-        "notes",
-    ]
-    final = "r'''\n"
-    for i in keys:
-        if i not in documentation:
-            continue
-        if isinstance(documentation[i], str):
-            sanitized = _sanitize(documentation[i])
-        else:
-            sanitized = documentation[i]
-        final += yaml.dump({i: sanitized}, indent=2)
-    final += "'''"
-    return final
 
 
 def path_to_name(path):

--- a/vmware_rest_code_generator/cmd/refresh_modules.py
+++ b/vmware_rest_code_generator/cmd/refresh_modules.py
@@ -432,7 +432,6 @@ class Resource:
 
 
 class AnsibleModuleBase(UtilsBase):
-
     def __init__(self, resource, definitions):
         super(AnsibleModuleBase, self).__init__()
         self.resource = resource
@@ -1038,7 +1037,10 @@ def main():
                 module = AnsibleInfoListOnlyModule(
                     resource, definitions=swagger_file.definitions
                 )
-                if module.is_trusted("vmware_rest_code_generator") and len(module.default_operationIds) > 0:
+                if (
+                    module.is_trusted("vmware_rest_code_generator")
+                    and len(module.default_operationIds) > 0
+                ):
                     module.renderer(
                         target_dir=args.target_dir, next_version=args.next_version
                     )
@@ -1047,7 +1049,10 @@ def main():
                 module = AnsibleInfoNoListModule(
                     resource, definitions=swagger_file.definitions
                 )
-                if module.is_trusted("vmware_rest_code_generator") and len(module.default_operationIds) > 0:
+                if (
+                    module.is_trusted("vmware_rest_code_generator")
+                    and len(module.default_operationIds) > 0
+                ):
                     module.renderer(
                         target_dir=args.target_dir, next_version=args.next_version
                     )
@@ -1055,7 +1060,10 @@ def main():
 
             module = AnsibleModule(resource, definitions=swagger_file.definitions)
 
-            if module.is_trusted("vmware_rest_code_generator") and len(module.default_operationIds) > 0:
+            if (
+                module.is_trusted("vmware_rest_code_generator")
+                and len(module.default_operationIds) > 0
+            ):
                 module.renderer(
                     target_dir=args.target_dir, next_version=args.next_version
                 )


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Depends-On: https://github.com/ansible-collections/gouttelette/pull/6

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR moves few functions from refresh_modules.py to  https://github.com/ansible-collections/gouttelette. These functions will be shared by https://github.com/ansible-collections/amazon_cloud_code_generator.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
